### PR TITLE
Base model refactor

### DIFF
--- a/samples/Sample.Templates/Views/Notification.cshtml
+++ b/samples/Sample.Templates/Views/Notification.cshtml
@@ -1,9 +1,9 @@
-﻿@model SampleService.Models.ServiceActionModel
+@model SampleService.Models.ServiceActionModel
 
 @{ 
     Layout = "_Layout";
 
-    Model.MailMessage.Subject = "Service status change 🤨";
+    Model.Subject = "Service status change 🤨";
 }
 
 <p>Current service action: @Model.ActionName. Executed at @Model.Timestamp</p>

--- a/samples/Sample.Templates/Views/Shared/_Layout.cshtml
+++ b/samples/Sample.Templates/Views/Shared/_Layout.cshtml
@@ -1,6 +1,6 @@
-﻿@model Skyhop.Mail.MailBase
+@model Skyhop.Mail.MailBase
 
-<p><strong>This mail is sent to @string.Join(", ", Model.MailMessage.To.Select(q => q.Name))</strong></p>
+<p><strong>This is some header</strong></p>
 
 @RenderBody()
 

--- a/src/Skyhop.Mail/MailBase.cs
+++ b/src/Skyhop.Mail/MailBase.cs
@@ -1,10 +1,29 @@
-﻿using MimeKit;
+using MimeKit;
+using System;
+using System.Collections.Generic;
 
 namespace Skyhop.Mail
 {
     public class MailBase
     {
-        public MimeMessage MailMessage { get; } = new MimeMessage();
-        public BodyBuilder BodyBuilder { get; } = new BodyBuilder();
+        public MailBase()
+            : this(new BodyBuilder())
+        { }
+
+        public MailBase(BodyBuilder bodyBuilder)
+        {
+            BodyBuilder = bodyBuilder;
+        }
+
+        public MessageImportance Importance { get; set; } = MessageImportance.Normal;
+        public MessagePriority Priority { get; set; } = MessagePriority.Normal;
+        public XMessagePriority XPriority { get; set; } = XMessagePriority.Normal;
+        public string Subject { get; set; } = "";
+        public AttachmentCollection Attachments
+            => BodyBuilder.Attachments;
+        public AttachmentCollection LinkedResources
+            => BodyBuilder.LinkedResources;
+
+        protected internal BodyBuilder BodyBuilder { get; }
     }
 }

--- a/src/Skyhop.Mail/MailDispatcher.cs
+++ b/src/Skyhop.Mail/MailDispatcher.cs
@@ -64,7 +64,11 @@ namespace Skyhop.Mail
 
             return new MimeMessage()
             {
-                Body = data.BodyBuilder.ToMessageBody()
+                Body = data.BodyBuilder.ToMessageBody(),
+                Subject = data.Subject,
+                Priority = data.Priority,
+                XPriority = data.XPriority,
+                Importance = data.Importance
             };
         }
 

--- a/src/Skyhop.Mail/MailDispatcher.cs
+++ b/src/Skyhop.Mail/MailDispatcher.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using MimeKit;
 using Skyhop.Mail.Abstractions;
 using Skyhop.Mail.Options;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -23,19 +24,24 @@ namespace Skyhop.Mail
 
         public async Task SendMail<T>(
             T data,
-            MailboxAddress? from = default,
-            MailboxAddress[]? to = default,
+            MailboxAddress[] to,
             MailboxAddress[]? cc = default,
             MailboxAddress[]? bcc = default,
+            MailboxAddress? from = default,
             MimeEntity[]? attachments = default) where T : MailBase
         {
+            from ??= _options.DefaultFromAddress ?? throw new ArgumentException(nameof(from), $"Either the parameter {nameof(from)} must be set or the {nameof(_options.DefaultFromAddress)} must be set.");
+            if (to.Length == 0)
+                throw new ArgumentException(nameof(to), $"There must be atleast one mail address in the {nameof(to)} parameter.");
+
             var message = await _fillMailMessage(data, attachments);
 
-            if (from != default || _options.DefaultFromAddress != default) message.From.Add(from ?? _options.DefaultFromAddress);
-
-            if (to != default && to.Any()) message.To.AddRange(to);
-            if (cc != default && cc.Any()) message.Cc.AddRange(cc);
-            if (bcc != default && bcc.Any()) message.Bcc.AddRange(bcc);
+            message.From.Add(from);
+            message.To.AddRange(to);
+            if (cc != default && cc.Any())
+                message.Cc.AddRange(cc);
+            if (bcc != default && bcc.Any())
+                message.Bcc.AddRange(bcc);
 
             await _mailSender.SendMail(message);
         }

--- a/src/Skyhop.Mail/MailDispatcher.cs
+++ b/src/Skyhop.Mail/MailDispatcher.cs
@@ -62,9 +62,10 @@ namespace Skyhop.Mail
                 }
             }
 
-            data.MailMessage.Body = data.BodyBuilder.ToMessageBody();
-
-            return data.MailMessage;
+            return new MimeMessage()
+            {
+                Body = data.BodyBuilder.ToMessageBody()
+            };
         }
 
         private async Task<(string HtmlBody, string TextBody)> _getBody<T>(T data)

--- a/src/Skyhop.Mail/PackageDetails.props
+++ b/src/Skyhop.Mail/PackageDetails.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <PackageVersion>2.0.0</PackageVersion>
+    <PackageVersion>3.0.0-rc1</PackageVersion>
     <VersionPrefix>0.0.1</VersionPrefix>
     <VersionPrefix Condition="'$(packageversion)' != ''">$(PackageVersion)</VersionPrefix>
     <VersionSuffix></VersionSuffix>
@@ -20,14 +20,7 @@
     <PackageProjectUrl>https://github.com/skyhop/Mail</PackageProjectUrl>
     <RepositoryUrl>https://github.com/skyhop/Mail</RepositoryUrl>
     <PackageReleaseNotes>
-      - Add bug fixed which resulted in email having no body,
-      - Removed dependency on WebHostBuilder
-      - Fixed a typo in AddMailDispatcher
-      - Removed the need to load all assemblies when trying to find a model/identifier combination
-      - Made MailSender awaitable
-      - Moved MailDispatcherOptions to options folder
-      - Moved IModelIdentifierLister to Abstractions folder
-      - Refactored the MailSender delegate to an interface, so now DI can be used for the send part
+      - Simplified MailBase class
     </PackageReleaseNotes>
   </PropertyGroup>
 


### PR DESCRIPTION
Only way to set the To, From, Cc & Bcc  are now using the MailDispatcher instead of also setting them in the MimeMessage. This makes the To parameter now required.

And the From parameter is optional, as long is the DefaultFromAddress is set. Otherwise an ArgumentException is thrown.